### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: quote_generator
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]
@@ -10,6 +13,8 @@ on:
 jobs:
   generate-contribute:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Generate GitHub contribution grid snake
@@ -33,6 +38,8 @@ jobs:
   update-readme:
     needs: generate-contribute
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/Justinianus2001/Justinianus2001/security/code-scanning/4](https://github.com/Justinianus2001/Justinianus2001/security/code-scanning/4)

The best way to address this issue is to explicitly add a `permissions` block to the workflow. You can do this at the root level, which applies to all jobs except those that override it, or within each individual job. In this case, since both jobs use GITHUB_TOKEN to push changes, they require `contents: write` permission. However, best practice is to use the least privilege: if only one job needs write access, give the other job read-only permissions.

- Add a workflow-level `permissions` block specifying the minimum required, e.g., `contents: read`.
- For any job that requires pushing to the repository (using git and GITHUB_TOKEN), add a job-specific `permissions: contents: write` block.
- Specifically, the `generate-contribute` job uses `crazy-max/ghaction-github-pages@v4` to push to the `output` branch, so it needs `contents: write`.
- The `update-readme` job pushes changes with git, so it also needs `contents: write`.

Implement the following changes in `.github/workflows/main.yml`:
- Insert a workflow-level `permissions: contents: read`.
- For both `generate-contribute` and `update-readme`, add `permissions: contents: write` at the job level (immediately after `runs-on:`).

No additional imports or definitions are needed for GitHub Actions YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
