### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/repo-interaction.yml
+++ b/.github/workflows/repo-interaction.yml
@@ -1,4 +1,8 @@
 name: repo-interaction
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
 
 on:
   issues:


### PR DESCRIPTION
Potential fix for [https://github.com/Justinianus2001/Justinianus2001/security/code-scanning/2](https://github.com/Justinianus2001/Justinianus2001/security/code-scanning/2)

To resolve this issue, add an explicit `permissions` block with the minimal set of permissions needed. The `actions/first-interaction` action creates comments in new issues and/or pull requests, so it requires `issues: write` (for issues) and `pull-requests: write` (for PRs). The action does not require access to repository contents. Therefore, add a `permissions` block at the workflow level (if all jobs require the same set) or at the job level with:
```yaml
permissions:
  issues: write
  pull-requests: write
  contents: read
```
This ensures that no unnecessary additional token privileges are present. You should place this block either immediately after the `name:` (line 1) or indented under the `check_interaction` job (line 11). Best practice is to put it at the workflow root so the restriction applies to all jobs by default.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
